### PR TITLE
Update create_judge_preference.sql

### DIFF
--- a/backend/create_judge_preference.sql
+++ b/backend/create_judge_preference.sql
@@ -1,6 +1,6 @@
 CREATE TABLE JudgePreference (
     judge_id int NOT NULL,
-    prize_name varchar(255) NOT NULL,
+    prize_name char(100) NOT NULL,
     PRIMARY KEY (judge_id, prize_name),
     FOREIGN KEY (judge_id) REFERENCES Judge(judge_id),
     FOREIGN KEY (prize_name) REFERENCES Prize(prize_name)


### PR DESCRIPTION
Having prize_name as a var_char(255) (variable length) makes the FK constraint fail, due to the fact that prize_name in the Prize table is a char(100)(padded with spaces to fit the length). Changing it to be a char(100) matches the padding.